### PR TITLE
use env in shebang.

### DIFF
--- a/remarkable.php
+++ b/remarkable.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 require_once __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
In non FHS-compilant filesystems, binaries are not available in the usual paths. Use
env to load the right application.

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>