### PR TITLE
update OTP URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library consists of three classes:
 * `splitbrain\ReMarkableAPI\ReMarkableFS` - the reMarkable stores all info in a flat hierarchy with documents identified by UUIDs only. This class makes the items accessible by path names (using `/` as a directory separator)
 * `splitbrain\ReMarkableAPI\Client` - this is just a thin wrapper around the Guzzle HTTP client which adds logging and handles authentication
 
-After instantiating the `ReMarkableAPI` object, you need to call either `register()` or `init()` on it before you can issue any of the other calls. The first call will register your client through a [8 char code](https://my.remarkable.com/generator-desktop/) and return an API token. You need to save that token somewhere and pass it to `init()` for subsequent calls. Have a look at the command line client in `remarkable.php` to see how to use it all.
+After instantiating the `ReMarkableAPI` object, you need to call either `register()` or `init()` on it before you can issue any of the other calls. The first call will register your client through a [8 char code](https://my.remarkable.com/device/connect/desktop/) and return an API token. You need to save that token somewhere and pass it to `init()` for subsequent calls. Have a look at the command line client in `remarkable.php` to see how to use it all.
 
 ## Command Line Client
 

--- a/remarkable.php
+++ b/remarkable.php
@@ -27,7 +27,7 @@ class Remarkable extends \splitbrain\phpcli\PSR3CLI
         $options->setHelp('A simple command line client to speak to the ReMarkable file API.');
 
         $options->registerCommand('register', 'Register this CLI as a new device using a code');
-        $options->registerArgument('code', 'The code obtained from https://my.remarkable.com/generator-desktop', true, 'register');
+        $options->registerArgument('code', 'The code obtained from https://my.remarkable.com/device/connect/desktop', true, 'register');
 
         $options->registerCommand('list', 'List all the available files');
 

--- a/src/RemarkableAPI.php
+++ b/src/RemarkableAPI.php
@@ -54,7 +54,7 @@ class RemarkableAPI
     /**
      * Exchange a website generated code against an auth token
      *
-     * @link https://my.remarkable.com/generator-desktop
+     * @link https://my.remarkable.com/device/connect/desktop
      *
      * @param string $code the auth code as displayed by the my.remarkable.com
      * @return string the bearer authentication token


### PR DESCRIPTION
The one-time code generator is a moving target. Update it to what works
for now.

Fixes issue #16. For now.

---

`/device/connect/remarkable` also seems to work; I can't locate the `/desktop` page by navigating unless I have already registered a desktop app there. But after registering this tool with the OTP from `/remarkable`, I noticed it was listed in my connected devices as a desktop Windows app anyways. ¯\_(ツ)_/¯